### PR TITLE
armv7 architecture support

### DIFF
--- a/neolink/build.yaml
+++ b/neolink/build.yaml
@@ -2,4 +2,5 @@ build_from:
   aarch64: homeassistant/aarch64-base-debian:latest
   amd64: homeassistant/amd64-base-debian:latest
   armhf: homeassistant/armhf-base-debian:latest
+  armv7: homeassistant/armv7-base-debian:latest
   i386: homeassistant/i386-base-debian:latest

--- a/neolink/config.yaml
+++ b/neolink/config.yaml
@@ -8,6 +8,7 @@ arch:
   - amd64
   - armhf
   - i386
+  - armv7
 ports:
   8554/tcp: 8554
 map:

--- a/neolink/run.sh
+++ b/neolink/run.sh
@@ -16,3 +16,7 @@ fi
 if [[ "i386" = *"${ARCH}"* ]]; then
     neolink_i386 rtsp --config /config/addons/neolink.toml
 fi
+
+if [[ "armv7" = *"${ARCH}"* ]]; then
+    neolink_armhf rtsp --config /config/addons/neolink.toml
+fi

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,4 +1,4 @@
 # https://developers.home-assistant.io/docs/add-ons/repository#repository-configuration
-name: dm82m Home Assistant add-on repository
-url: 'https://github.com/dm82m/hassio-addons'
-maintainer: Dirk <dirk@maucher-online.de>
+name: spoler Home Assistant add-on repository
+url: 'https://github.com/spoler/hassio-addons/'
+maintainer: Spoler

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,4 +1,4 @@
 # https://developers.home-assistant.io/docs/add-ons/repository#repository-configuration
-name: spoler Home Assistant add-on repository
-url: 'https://github.com/spoler/hassio-addons/'
-maintainer: Spoler
+name: dm82m Home Assistant add-on repository
+url: 'https://github.com/dm82m/hassio-addons'
+maintainer: Dirk <dirk@maucher-online.de>


### PR DESCRIPTION
Added armv7 support. 

It uses neolink_armhf build.

Tested on Raspberry Pi 4 with latest HassOS.