### PR TITLE
Fix run.sh

### DIFF
--- a/neolink/run.sh
+++ b/neolink/run.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/with-contenv bashio
+#!/bin/bash
 
 neolink rtsp --config /config/addons/neolink.toml


### PR DESCRIPTION
This should get your run.sh to work using the docker image method. From your errors in #10 the issues were this:

1. Docker method:
     You used `/usr/bin/with-contenv` as the shebang which is nor present in the image. If you want it then please install it from here. https://github.com/just-containers/s6-overlay#container-environment
2. Binary method:
    The glib version in your base image is too old. You needed to use a newer base image. I am not sure how often that base image of `homeassistant/*-base-debian:latest`  is updated though so maybe you'd need a newer base entirly