### PR TITLE
Dual mode (rtsp/mqtt)

### DIFF
--- a/neolink/config.yaml
+++ b/neolink/config.yaml
@@ -1,6 +1,6 @@
 name: "Neolink"
 description: "Will run Neolink directly as Add-on in HAOS"
-version: "0.0.5"
+version: "0.0.6"
 slug: "neolink"
 init: false
 arch:

--- a/neolink/config.yaml
+++ b/neolink/config.yaml
@@ -16,4 +16,4 @@ map:
 options:
   mode: rtsp
 schema:
-  mode: list(rtsp|mqtt)
+  mode: list(rtsp|mqtt|dual)

--- a/neolink/run.sh
+++ b/neolink/run.sh
@@ -11,4 +11,25 @@ echo -n "neolink version: " && neolink --version
 echo "neolink mode: ${MODE}"
 echo "ATTENTION: if you expected a newer Neolink version, please reinstall this Add-on!"
 echo "--- Neolink ---"
-neolink ${MODE} --config /config/addons/neolink.toml
+
+case $MODE in
+  rtsp)
+    neolink rtsp --config /config/addons/neolink.toml
+    ;;
+
+  mqtt)
+    neolink mqtt --config /config/addons/neolink.toml
+    ;;
+
+  dual)
+    neolink rtsp --config /config/addons/neolink.toml &
+
+	neolink mqtt --config /config/addons/neolink.toml &
+
+	wait
+    ;;
+
+  *)
+    echo -n "Unknown mode option"
+    ;;
+esac

--- a/neolink/translations/en.yaml
+++ b/neolink/translations/en.yaml
@@ -1,4 +1,4 @@
 configuration:
   mode:
     name: Operating Mode
-    description: Defaults to RTSP. You can also choose MQTT if you want to run Neolink in MQTT operating mode.
+    description: Defaults to RTSP. You can also choose MQTT if you want to run Neolink in MQTT operating mode, or dual mode for both RTSP and MQTT.

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,4 +1,4 @@
 # https://developers.home-assistant.io/docs/add-ons/repository#repository-configuration
 name: dm82m Home Assistant add-on repository
-url: 'https://github.com/AdrianosBates/hassio-addons'
+url: 'https://github.com/dm82m/hassio-addons'
 maintainer: Dirk <dirk@maucher-online.de>

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,4 +1,4 @@
 # https://developers.home-assistant.io/docs/add-ons/repository#repository-configuration
 name: dm82m Home Assistant add-on repository
-url: 'https://github.com/dm82m/hassio-addons'
+url: 'https://github.com/AdrianosBates/hassio-addons'
 maintainer: Dirk <dirk@maucher-online.de>


### PR DESCRIPTION
I have made changes that allow the neolink home assistant addon to run both rtsp and mqtt at the same time in 'dual' mode, and added a configuration option to reflect that. Everything seems to work well in my testing.