### PR TITLE
use host_network for neolink

### DIFF
--- a/neolink/config.yaml
+++ b/neolink/config.yaml
@@ -1,7 +1,8 @@
 name: "Neolink"
 description: "Will run Neolink directly as Add-on in HAOS"
-version: "0.0.8"
+version: "0.0.9"
 slug: "neolink"
+host_network: true
 init: false
 arch:
   - aarch64


### PR DESCRIPTION
Use host_network for neolink
As currently it tries to register push notifications with the internal docker ip
Which the cameras can't access