### PR TITLE
use version 0.6.2

### DIFF
--- a/neolink/Dockerfile
+++ b/neolink/Dockerfile
@@ -1,4 +1,4 @@
-FROM quantumentangledandy/neolink:latest
+FROM quantumentangledandy/neolink:v0.6.2
 
 RUN apt-get update && \
     apt-get install -y \

--- a/neolink/config.yaml
+++ b/neolink/config.yaml
@@ -1,6 +1,6 @@
 name: "Neolink"
 description: "Will run Neolink directly as Add-on in HAOS"
-version: "0.0.8"
+version: "0.0.9"
 slug: "neolink"
 init: false
 arch:

--- a/neolink/run.sh
+++ b/neolink/run.sh
@@ -7,7 +7,7 @@ MODE=$(jq --raw-output '.mode // empty' $CONFIG_PATH)
 LOG=$(jq --raw-output '.log // empty' $CONFIG_PATH)
 
 echo "--- VERSIONS ---"
-echo "add-on version: 0.0.8"
+echo "add-on version: 0.0.9"
 echo -n "neolink version: " && neolink --version
 echo "neolink mode: ${MODE}"
 echo "neolink log: ${LOG}"


### PR DESCRIPTION
currently the is bug with the release candiate, so its best to use an old version until its a new version is released

also saves time having to not rebuild every single time the `latest` gets updated!