### PR TITLE
Update neolink configuration link in readme's

### DIFF
--- a/neolink-latest/README.md
+++ b/neolink-latest/README.md
@@ -22,7 +22,7 @@ This add-on allows you to run latest Neolink directly on your HAOS instance. If 
 1. Install this add-on in your HAOS instance.
 2. The operating mode of Neolink defaults to `RTSP`. If you prefer `MQTT`, please change it within the add-on configuration. Or select `DUAL` if you want to use RTSP and MQTT in parallel.
 3. Create the configuration file named `neolink.toml` in your HAOS `/addon_configs/a14d3924_neolink-latest/` folder.
-   - For configuration please follow [these](https://github.com/QuantumEntangledAndy/neolink#configuration) instructions.
+   - For configuration please follow [these](https://github.com/QuantumEntangledAndy/neolink#configusage) instructions.
    - Sample config file can be found [here](https://raw.githubusercontent.com/QuantumEntangledAndy/neolink/master/sample_config.toml).
 4. Start the add-on and check the log output.
 5. The log level defaults to `INFO`. You can set it to error, warn, info, or debug. Most users can leave it at info, but debug can be helpful if you have issues.

--- a/neolink/README.md
+++ b/neolink/README.md
@@ -22,7 +22,7 @@ This add-on allows you to run Neolink directly on your HAOS instance. If you don
 1. Install this add-on in your HAOS instance.
 2. The operating mode of Neolink defaults to `RTSP`. If you prefer `MQTT`, please change it within the add-on configuration. Or select `DUAL` if you want to use RTSP and MQTT in parallel.
 3. Create the configuration file named `neolink.toml` in your HAOS `/addon_configs/a14d3924_neolink/` folder.
-   - For configuration please follow [these](https://github.com/QuantumEntangledAndy/neolink#configuration) instructions.
+   - For configuration please follow [these](https://github.com/QuantumEntangledAndy/neolink#configusage) instructions.
    - Sample config file can be found [here](https://raw.githubusercontent.com/QuantumEntangledAndy/neolink/master/sample_config.toml).
 4. Start the add-on and check the log output.
 5. The log level defaults to `INFO`. You can set it to error, warn, info, or debug. Most users can leave it at info, but debug can be helpful if you have issues.


### PR DESCRIPTION
Just noticed the link id sections were named differently, so the current ones don't skip you to the correct section