### PR TITLE
Add link to mydealz2rss

### DIFF
--- a/mydealz2rss/mydealz.py
+++ b/mydealz2rss/mydealz.py
@@ -93,6 +93,7 @@ def generate_rss(deals):
         fe = fg.add_entry()
         fe.title(deal["title"])
         fe.guid(deal["link"], True)
+        fe.link(href=deal["link"])
         fe.description(deal["summary"])
         fe.pubDate(deal["pubDate"])
 


### PR DESCRIPTION
First of all: Thank you for this great addon! 😊

I have noticed that my RSS reader ([Feeder](https://github.com/spacecowboy/Feeder)) does not recognize the `isPermaLink` attribute in the `guid` of each feed entry. Thus, there is no link which allows me to open the entry in the browser. Based on the [RSS specification](https://www.rssboard.org/rss-specification#ltguidgtSubelementOfLtitemgt), this is actually valid behavior of the RSS reader:

> If the guid element has an attribute named isPermaLink with a value of true, the reader may assume that it is a permalink to the item [...]

Because of that, this PR adds a `link` to each feed entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * RSS feed entries now correctly include direct links to each deal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->